### PR TITLE
Implement elegant link to original post

### DIFF
--- a/src/components/OriginalPostCallout.jsx
+++ b/src/components/OriginalPostCallout.jsx
@@ -1,0 +1,69 @@
+import { useState } from 'react';
+import PropTypes from 'prop-types';
+import { trackEvent, trackOutboundLink } from '../utils/analytics';
+
+export default function OriginalPostCallout({ url, source = 'WordPress', compact = false }) {
+  const [copied, setCopied] = useState(false);
+
+  const handleCopy = async () => {
+    try {
+      await navigator.clipboard.writeText(url);
+      setCopied(true);
+      trackEvent('copy_original_post_link', { url, source });
+      setTimeout(() => setCopied(false), 1500);
+    } catch (e) {
+      trackEvent('copy_original_post_link_failed', { url, source, message: e?.message });
+    }
+  };
+
+  const handleVisit = () => {
+    trackOutboundLink(url, { source, placement: 'elsewhere_callout' });
+  };
+
+  return (
+    <div className={`group relative overflow-hidden rounded-xl border border-gray-200 bg-gradient-to-br from-gray-50 to-white ${compact ? 'p-3' : 'p-4'} shadow-sm hover:shadow transition-shadow`}> 
+      <div className="pointer-events-none absolute inset-0 opacity-0 group-hover:opacity-100 transition-opacity" aria-hidden>
+        <div className="absolute -top-6 -right-6 h-16 w-16 rounded-full bg-blue-100"></div>
+      </div>
+      <div className="flex flex-col md:flex-row md:items-center md:justify-between gap-3 relative">
+        <div className="flex items-start gap-3">
+          <div className="mt-0.5 h-6 w-6 flex items-center justify-center rounded-full bg-blue-600 text-white">↗</div>
+          <div>
+            <p className="text-sm text-gray-600">This post lives on {source}.</p>
+            <p className="text-base md:text-lg font-medium text-gray-900">Click to read the original post</p>
+          </div>
+        </div>
+
+        <div className="flex items-center gap-2">
+          <a
+            href={url}
+            target="_blank"
+            rel="noopener noreferrer"
+            onClick={handleVisit}
+            className="inline-flex items-center gap-2 rounded-lg bg-blue-600 px-3 py-2 text-white hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-blue-400 focus:ring-offset-2"
+            aria-label={`Open original post on ${source}`}
+          >
+            Read original
+            <span aria-hidden>↗</span>
+          </a>
+          <button
+            type="button"
+            onClick={handleCopy}
+            className="inline-flex items-center gap-2 rounded-lg border border-gray-300 bg-white px-3 py-2 text-gray-700 hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-blue-400 focus:ring-offset-2"
+            aria-live="polite"
+            aria-label="Copy original link"
+          >
+            {copied ? 'Copied' : 'Copy link'}
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+OriginalPostCallout.propTypes = {
+  url: PropTypes.string.isRequired,
+  source: PropTypes.string,
+  compact: PropTypes.bool,
+};
+

--- a/src/pages/Elsewhere.jsx
+++ b/src/pages/Elsewhere.jsx
@@ -1,6 +1,8 @@
 import { useEffect, useState } from 'react';
 import { Link } from 'react-router-dom';
 import SEO from '../components/SEO';
+import OriginalPostCallout from '../components/OriginalPostCallout';
+import { trackEvent } from '../utils/analytics';
 
 export default function Elsewhere() {
   const [posts, setPosts] = useState([]);
@@ -118,25 +120,31 @@ export default function Elsewhere() {
             </div>
           )}
           {!loading && !error && posts.length > 0 && (
-            <ul className="space-y-4">
+            <ul className="space-y-6">
               {posts.slice(0, 10).map((p) => (
-                <li key={p.guid} className="bg-white p-4 rounded-lg shadow">
-                  <a
-                    href={p.link}
-                    target="_blank"
-                    rel="noopener noreferrer"
-                    className="text-lg font-semibold text-blue-700 hover:text-blue-800"
-                  >
-                    {decodeEntities(p.title)}
-                  </a>
-                  <div className="text-sm text-gray-500">
-                    {new Date(p.pubDate).toLocaleDateString()}
+                <li key={p.guid} className="bg-white p-5 rounded-xl shadow border border-gray-100">
+                  <div className="flex flex-col gap-3">
+                    <a
+                      href={p.link}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      onClick={() => trackEvent('elsewhere_post_title_click', { url: p.link })}
+                      className="text-lg font-semibold text-blue-700 hover:text-blue-800"
+                    >
+                      {decodeEntities(p.title)}
+                    </a>
+                    <div className="text-sm text-gray-500">
+                      {new Date(p.pubDate).toLocaleDateString()}
+                    </div>
+                    {p.excerpt && (
+                      <p className="text-gray-700 mt-1">
+                        {decodeEntities(p.excerpt)}…
+                      </p>
+                    )}
+                    <div className="pt-2">
+                      <OriginalPostCallout url={p.link} source="WordPress" compact />
+                    </div>
                   </div>
-                  {p.excerpt && (
-                    <p className="text-gray-700 mt-2">
-                      {decodeEntities(p.excerpt)}…
-                    </p>
-                  )}
                 </li>
               ))}
             </ul>

--- a/src/utils/analytics.js
+++ b/src/utils/analytics.js
@@ -1,0 +1,18 @@
+export function trackEvent(eventName, parameters = {}, options = {}) {
+  const { category = 'engagement', label = eventName } = options;
+  if (typeof window !== 'undefined' && typeof window.gtag === 'function') {
+    window.gtag('event', eventName, {
+      event_category: category,
+      event_label: label,
+      ...parameters,
+    });
+  }
+}
+
+export function trackOutboundLink(url, context = {}) {
+  trackEvent('outbound_click', { url, ...context }, {
+    category: 'outbound',
+    label: 'outbound_click',
+  });
+}
+


### PR DESCRIPTION
Add an elegant "Read original post" callout to the `/elsewhere` page with copy link and analytics tracking.

This PR implements a dedicated, visually appealing component to guide users to the original source of posts listed on the `/elsewhere` page, fulfilling the request for an "elegant UI/UX" and "state of the art" solution. It includes copy-to-clipboard functionality and Google Analytics 4 tracking for user interactions.

---
<a href="https://cursor.com/background-agent?bcId=bc-c4587ea3-010d-4a0c-8ede-22456b462d9e">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-c4587ea3-010d-4a0c-8ede-22456b462d9e">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

